### PR TITLE
Potential fix for code scanning alert no. 4: Uncontrolled data used in path expression

### DIFF
--- a/restaurant/src/main/java/ku/cs/restaurant/service/ImageService.java
+++ b/restaurant/src/main/java/ku/cs/restaurant/service/ImageService.java
@@ -13,8 +13,16 @@ import java.nio.file.StandardCopyOption;
 public class ImageService {
     public String saveImage(String folderPath, MultipartFile image) throws IOException {
         Files.createDirectories(Paths.get(folderPath));
-        String fileName = System.currentTimeMillis() + "_" + image.getOriginalFilename();
-        Path path = Paths.get(folderPath, fileName);
+        String originalFileName = image.getOriginalFilename();
+        if (originalFileName.contains("..") || originalFileName.contains("/") || originalFileName.contains("\\")) {
+            throw new IllegalArgumentException("Invalid filename");
+        }
+        String fileName = System.currentTimeMillis() + "_" + originalFileName;
+        Path path = Paths.get(folderPath, fileName).normalize().toAbsolutePath();
+        Path folder = Paths.get(folderPath).normalize().toAbsolutePath();
+        if (!path.startsWith(folder)) {
+            throw new IllegalArgumentException("Invalid filename");
+        }
         Files.copy(image.getInputStream(), path, StandardCopyOption.REPLACE_EXISTING);
         return path.toString();
     }


### PR DESCRIPTION
Potential fix for [https://github.com/Particulate-Matter-2-5/restaurant-transport/security/code-scanning/4](https://github.com/Particulate-Matter-2-5/restaurant-transport/security/code-scanning/4)

To fix the problem, we need to validate the user-provided filename to ensure it does not contain any path traversal characters or separators. This can be done by checking for the presence of "..", "/", or "\\" in the filename and rejecting the input if any are found. Additionally, we should ensure that the resolved path stays within the intended directory.

1. Add validation to check for path traversal characters in the filename.
2. Ensure the resolved path is within the intended directory.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
