### PR TITLE
Potential fix for code scanning alert no. 2: Uncontrolled data used in path expression

### DIFF
--- a/restaurant/src/main/java/ku/cs/restaurant/controller/ImageController.java
+++ b/restaurant/src/main/java/ku/cs/restaurant/controller/ImageController.java
@@ -20,6 +20,9 @@ public class ImageController {
     @GetMapping("/images/foods/{filename:.+}")
     public ResponseEntity<Resource> getFoodImage(@PathVariable String filename) {
         try {
+            if (filename.contains("..") || filename.contains("/") || filename.contains("\\")) {
+                throw new IllegalArgumentException("Invalid filename");
+            }
             Resource resource = resourceLoader.getResource("classpath:images/foods/" + filename);
             if (!resource.exists())
                 return ResponseEntity.status(HttpStatus.NOT_FOUND).build();
@@ -36,6 +39,9 @@ public class ImageController {
     @GetMapping("/images/ingredients/{filename:.+}")
     public ResponseEntity<Resource> getIngredientImage(@PathVariable String filename) {
         try {
+            if (filename.contains("..") || filename.contains("/") || filename.contains("\\")) {
+                throw new IllegalArgumentException("Invalid filename");
+            }
             Resource resource = resourceLoader.getResource("classpath:images/ingredients/" + filename);
             if (!resource.exists())
                 return ResponseEntity.status(HttpStatus.NOT_FOUND).build();


### PR DESCRIPTION
Potential fix for [https://github.com/Particulate-Matter-2-5/restaurant-transport/security/code-scanning/2](https://github.com/Particulate-Matter-2-5/restaurant-transport/security/code-scanning/2)

To fix the problem, we need to validate the `filename` parameter to ensure it does not contain any path traversal characters or sequences. This can be done by checking for the presence of "..", "/", or "\\" in the `filename`. If any of these characters or sequences are found, we should reject the input by throwing an `IllegalArgumentException`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
